### PR TITLE
Use docker gateway routed mode

### DIFF
--- a/src/network/compose.yaml
+++ b/src/network/compose.yaml
@@ -58,6 +58,8 @@ services:
 networks:
   router_client:
     driver: bridge
+    driver_opts:
+      com.docker.network.bridge.gateway_mode_ipv4: routed
     ipam:
       driver: default
       config:
@@ -65,6 +67,8 @@ networks:
           gateway: 192.168.112.1
   router_server:
     driver: bridge
+    driver_opts:
+      com.docker.network.bridge.gateway_mode_ipv4: routed
     ipam:
       driver: default
       config:


### PR DESCRIPTION
With recent docker (around 28.X) , and Ubuntu 24.04, routing is not setup by default by Docker.
The error show as hanging, and eventually failing

```
cd src/network
bash scripts/teardown_containers.sh
bash scripts/setup_containers.sh
bash scripts/setup_network.sh 
Executing: scripts/setup_network.sh
client: 
```

As a workaround use "routed" gateway mode, instead of the default "nat" https://docs.docker.com/engine/network/packet-filtering-firewalls/#gateway-modes